### PR TITLE
Add Agentic Engineering Jobs to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [Startup Jobs](https://startup.jobs/remote)
 - [4DayJob](https://4dayjob.com) - Job board for 4-day work week positions across all industries, with 1,500+ remote and flexible jobs
 - [RemoteFR](https://remotefr.com)
+- [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
Adding https://agentic-engineering-jobs.com to the 🧳 Jobs section.

It's a job board for engineers building agentic systems — RAG pipelines, AI agents, LLM-powered products, agent orchestration. Most listings are remote-first.

- 500+ active listings
- Free to post for companies, free to browse for job seekers
- Appended to the existing Jobs section