### PR TITLE
Add AI Dev Jobs to job boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [4DayJob](https://4dayjob.com) - Job board for 4-day work week positions across all industries, with 1,500+ remote and flexible jobs
 - [RemoteFR](https://remotefr.com)
 - [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
+- [AI Dev Jobs](https://aidevboard.com) - AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Filter by remote/hybrid/onsite.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
Added [AI Dev Jobs](https://aidevboard.com) — an AI/ML-focused job board with a public REST API for programmatic access. Aggregates remote AI roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Supports filtering by remote/hybrid/onsite.