### PR TITLE
Add Meridian to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 
 ## 🧳 Jobs
 
+- [Meridian, remote tech jobs matched to your timezone for US, LATAM and EU](https://meridianremote.com)
 - [Remote|Ok, Today's remote jobs](https://remoteok.io/)
 - [RemoteYeah, Remote Software Developer jobs](https://remoteyeah.com/)
 - [Remote Vibe Coding Jobs - Remote developer jobs at AI-native, async-first companies](https://remotevibecodingjobs.com)


### PR DESCRIPTION
Adds [Meridian](https://meridianremote.com) — a remote tech job board that matches roles to your timezone for US, LATAM, and EU professionals, aggregating and deduplicating listings from top boards and ATS feeds while linking to the original posting.