### PR TITLE
➕ Add RemoteJobs.lat to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [RemoteFR](https://remotefr.com)
 - [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 - [AI Dev Jobs](https://aidevboard.com) - AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Filter by remote/hybrid/onsite.
+- [RemoteJobs.lat](https://remotejobs.lat) - Remote job board for Latin American tech professionals.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
Adding RemoteJobs.lat, a remote job board for LATAM tech professionals.

Small one-line addition to the Jobs list.