### PR TITLE
Add CountLink to digital events tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [StreamYard](https://streamyard.com/)
 - [Twitch](https://www.twitch.tv/)
 - [Open Broadcaster Software OBS](https://obsproject.com/fr)
+- [CountLink](https://countlink.app) - Free, no-signup shared countdown timer. Set a duration or a target time, copy the link, and every device that opens it counts down to the exact same instant — handy for a synced "starting in..." countdown before a stream or webinar begins.
 - [Livestorm](https://livestorm.co/fr/)
 - [Remo](https://remo.co/)
 - [Hopin](https://hopin.to/)


### PR DESCRIPTION
Adding [CountLink](https://countlink.app) next to OBS/Twitch in the "Tools to set-up digital events" section — a free, no-signup shared countdown timer. Set a duration or a target time and share the link; everyone who opens it (co-hosts, attendees, a stream overlay) sees the exact same countdown, computed from a timestamp in the URL rather than a server, so there's no account and no drift between devices. Useful for a synced "starting in..." countdown before a stream or webinar begins.