### PR TITLE
➕ Add Jobs in JS to Jobs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ The Best Way to Totally Stress Out Your Team by Basecamp](https://basecamp.com/g
 - [Agentic Engineering Jobs](https://agentic-engineering-jobs.com) - Job board for engineers building agentic systems (RAG, AI agents, LLM-powered products, agent orchestration). Free to post, free to browse.
 - [AI Dev Jobs](https://aidevboard.com) - AI and ML job board with public REST API. Aggregates roles from 55+ ATS sources including Greenhouse, Lever, and Ashby. Filter by remote/hybrid/onsite.
 - [RemoteJobs.lat](https://remotejobs.lat) - Remote job board for Latin American tech professionals.
+- [Jobs in JS](https://jobsinjs.com/remote-javascript-jobs/) - Remote JavaScript jobs.
 
 ## 🏡 Equipment
 


### PR DESCRIPTION
Adding https://jobsinjs.com/remote-javascript-jobs/ to the Jobs section.

Jobs in JS is a job board for JavaScript developers. The linked page collects remote JavaScript roles.